### PR TITLE
Added a note in ros2_controllers.yaml to clarify effort control frequency requirements.

### DIFF
--- a/panda_resources/panda_moveit_config/config/ros2_controllers.yaml
+++ b/panda_resources/panda_moveit_config/config/ros2_controllers.yaml
@@ -1,7 +1,8 @@
 # This config file is used by ros2_control
 controller_manager:
   ros__parameters:
-    update_rate: 100  # Hz
+    # Set at least above 200 Hz for effort command interface.
+    update_rate: 100  # Hz 
 
     panda_arm_controller:
       type: joint_trajectory_controller/JointTrajectoryController


### PR DESCRIPTION
When using the effort command interface at 100 Hz, the control loop is too slow to provide stable force/torque commands. This delay results in insufficient responsiveness, causing the robot to oscillate and swing uncontrollably due to delayed corrections. The low update rate fails to properly regulate the applied effort, leading to instability in the control system. Increasing the control frequency to at least 200 Hz ensures smoother control.