### PR TITLE
[Bugfix] Fix ft sensor error

### DIFF
--- a/panda_resources/panda_moveit_config/config/panda.ros2_control.xacro
+++ b/panda_resources/panda_moveit_config/config/panda.ros2_control.xacro
@@ -144,14 +144,14 @@
                   <param name="initial_value">0.0</param>
                 </state_interface>
             </joint>
-            <sensor name="ft_sensor">
+            <sensor name="sensor_fts">
               <state_interface name="force.x"/>
               <state_interface name="force.y"/>
               <state_interface name="force.z"/>
               <state_interface name="torque.x"/>
               <state_interface name="torque.y"/>
               <state_interface name="torque.z"/>
-              <param name="frame_id">ft_sensor</param>
+              <param name="frame_id">sensor_fts</param>
             </sensor>
         </ros2_control>
     </xacro:macro>

--- a/panda_resources/panda_moveit_config/config/ros2_controllers.yaml
+++ b/panda_resources/panda_moveit_config/config/ros2_controllers.yaml
@@ -72,8 +72,8 @@ panda_hand_controller:
 
 force_torque_broadcaster:
   ros__parameters:
-    frame_id: ft_sensor
-    sensor_name: ft_sensor
+    frame_id: sensor_fts
+    sensor_name: sensor_fts
 
 admittance_controller:
   ros__parameters:
@@ -100,7 +100,7 @@ admittance_controller:
       tip: panda_hand  # The end effector frame
       alpha: 0.05
     ft_sensor:
-      name: ft_sensor
+      name: sensor_fts
       frame:
         id: panda_link7  # Wrench measurements are in this frame
       filter_coefficient: 0.1

--- a/panda_resources/panda_mujoco/franka_emika_panda/panda.xml
+++ b/panda_resources/panda_mujoco/franka_emika_panda/panda.xml
@@ -291,7 +291,7 @@
                     <geom mesh="link7_6" material="black" class="visual"/>
                     <geom mesh="link7_7" material="white" class="visual"/>
                     <geom mesh="link7_c" class="collision"/>
-                    <site name="ft_sensor_site" pos="0 0 0"/>
+                    <site name="sensor_fts_site" pos="0 0 0"/>
                     <body name="hand" pos="0 0 0.107" quat="0.9238795 0 0 -0.3826834">
                       <inertial mass="0.73" pos="-0.01 0 0.03" diaginertia="0.001 0.0025 0.0017"/>
                       <geom mesh="hand_0" material="off_white" class="visual"/>
@@ -422,8 +422,8 @@
   </worldbody>
 
   <sensor>
-    <force name="ft_sensor_force" site="ft_sensor_site"/>
-    <torque name="ft_sensor_torque" site="ft_sensor_site"/>
+    <force name="sensor_force" site="sensor_fts_site"/>
+    <torque name="sensor_torque" site="sensor_fts_site"/>
   </sensor>
 
   <tendon>


### PR DESCRIPTION
Addresses #8.
Since [this pr](https://github.com/moveit/mujoco_ros2_control/pull/36), ft sensor should include `fts` in sensor name.